### PR TITLE
Add an option to optionaly try to invoke ctor

### DIFF
--- a/KGySoft.CoreLibraries.UnitTest/UnitTests/Serialization/Binary/CtorInvocationTests.cs
+++ b/KGySoft.CoreLibraries.UnitTest/UnitTests/Serialization/Binary/CtorInvocationTests.cs
@@ -1,0 +1,78 @@
+﻿using KGySoft.Serialization.Binary;
+
+using NUnit.Framework;
+
+namespace KGySoft.CoreLibraries.UnitTests.Serialization.Binary
+{
+    [TestFixture]
+    public class CtorInvocationTests
+    {
+        [Test]
+        public void InvokeCtor()
+        {
+            TestClass.CtorInvocationCounter = 0;
+
+            var obj = new TestClass();
+
+            var data = KGySoft.Serialization.Binary.BinarySerializer
+                .Serialize(obj, BinarySerializationOptions.RecursiveSerializationAsFallback);
+
+            var result = KGySoft.Serialization.Binary.BinarySerializer.Deserialize<TestClass>(data, 0,
+                BinarySerializationOptions.AlwaysTryInvokeCtorWhenDeserializing);
+
+            Assert.AreEqual(2, TestClass.CtorInvocationCounter);
+        }
+
+        [Test]
+        public void DoNotInvokeCtor()
+        {
+            TestClass.CtorInvocationCounter = 0;
+
+            var obj = new TestClass();
+
+            var data = KGySoft.Serialization.Binary.BinarySerializer
+                .Serialize(obj, BinarySerializationOptions.RecursiveSerializationAsFallback);
+
+            var result = KGySoft.Serialization.Binary.BinarySerializer.Deserialize<TestClass>(data, 0,
+                BinarySerializationOptions.None);
+
+            Assert.AreEqual(1, TestClass.CtorInvocationCounter);
+        }
+
+        [Test]
+        public void DoNotCrashWhenClassDoesNotHaveParameterlessCtor()
+        {
+            TestCalssWithBadCtor.CtorInvocationCounter = 0;
+
+            var obj = new TestCalssWithBadCtor("", 0);
+
+            var data = KGySoft.Serialization.Binary.BinarySerializer
+                .Serialize(obj, BinarySerializationOptions.RecursiveSerializationAsFallback);
+
+            var result = KGySoft.Serialization.Binary.BinarySerializer.Deserialize<TestCalssWithBadCtor>(data, 0,
+                BinarySerializationOptions.AlwaysTryInvokeCtorWhenDeserializing);
+
+            Assert.AreEqual(1, TestCalssWithBadCtor.CtorInvocationCounter);
+        }
+
+        class TestClass
+        {
+            public static int CtorInvocationCounter = 0;
+
+            public TestClass()
+            {
+                CtorInvocationCounter++;
+            }
+        }
+
+        class TestCalssWithBadCtor
+        {
+            public static int CtorInvocationCounter = 0;
+            public TestCalssWithBadCtor(string foo, int bar)
+            {
+                CtorInvocationCounter++;
+            }
+        }
+    }
+
+}

--- a/KGySoft.CoreLibraries.UnitTest/UnitTests/Serialization/Binary/CtorInvocationTests.cs
+++ b/KGySoft.CoreLibraries.UnitTest/UnitTests/Serialization/Binary/CtorInvocationTests.cs
@@ -24,6 +24,22 @@ namespace KGySoft.CoreLibraries.UnitTests.Serialization.Binary
         }
 
         [Test]
+        public void DoNotInvokeIBinarySerializableCtorWithoutInterface()
+        {
+            TestClassWithIBinarySerializableCtor.CtorInvocationCounter = 0;
+
+            var obj = new TestClassWithIBinarySerializableCtor(BinarySerializationOptions.None, new byte[0]);
+
+            var data = KGySoft.Serialization.Binary.BinarySerializer
+                .Serialize(obj, BinarySerializationOptions.RecursiveSerializationAsFallback);
+
+            var result = KGySoft.Serialization.Binary.BinarySerializer.Deserialize<TestClassWithIBinarySerializableCtor>(data, 0,
+                BinarySerializationOptions.AlwaysTryInvokeCtorWhenDeserializing);
+
+            Assert.AreEqual(1, TestClassWithIBinarySerializableCtor.CtorInvocationCounter);
+        }
+
+        [Test]
         public void DoNotInvokeCtor()
         {
             TestClass.CtorInvocationCounter = 0;
@@ -68,7 +84,19 @@ namespace KGySoft.CoreLibraries.UnitTests.Serialization.Binary
         class TestCalssWithBadCtor
         {
             public static int CtorInvocationCounter = 0;
+
             public TestCalssWithBadCtor(string foo, int bar)
+            {
+                CtorInvocationCounter++;
+            }
+        }
+
+        // NOT an IBinarySerializable, but with matching ctor
+        class TestClassWithIBinarySerializableCtor
+        {
+            public static int CtorInvocationCounter = 0;
+
+            public TestClassWithIBinarySerializableCtor(BinarySerializationOptions options, byte[] serData)
             {
                 CtorInvocationCounter++;
             }

--- a/KGySoft.CoreLibraries/Serialization/Binary/BinarySerializationFormatter.DeserializationManager.cs
+++ b/KGySoft.CoreLibraries/Serialization/Binary/BinarySerializationFormatter.DeserializationManager.cs
@@ -692,7 +692,8 @@ namespace KGySoft.Serialization.Binary
                         | BinarySerializationOptions.IgnoreISerializable 
                         | BinarySerializationOptions.IgnoreIObjectReference
                         | BinarySerializationOptions.SafeMode
-                        | BinarySerializationOptions.AllowNonSerializableExpectedCustomTypes),
+                        | BinarySerializationOptions.AllowNonSerializableExpectedCustomTypes
+                        | BinarySerializationOptions.AlwaysTryInvokeCtorWhenDeserializing),
                     binder, surrogateSelector)
             {
                 this.rootType = rootType == Reflector.ObjectType ? null : rootType;
@@ -2273,7 +2274,8 @@ namespace KGySoft.Serialization.Binary
                         Throw.SerializationException(Res.BinarySerializationCannotCreateSerializableObjectSafe(type));
                 }
 
-                if (!Reflector.TryCreateEmptyObject(type, false, true, out object? obj))
+                bool tryInvokeCtor = base.Options.HasFlag(BinarySerializationOptions.AlwaysTryInvokeCtorWhenDeserializing);
+                if (!Reflector.TryCreateEmptyObject(type, tryInvokeCtor, true, out object? obj))
                     Throw.SerializationException(Res.BinarySerializationCannotCreateUninitializedObject(type));
                 return obj;
             }

--- a/KGySoft.CoreLibraries/Serialization/Binary/_Enums/BinarySerializationOptions.cs
+++ b/KGySoft.CoreLibraries/Serialization/Binary/_Enums/BinarySerializationOptions.cs
@@ -192,5 +192,12 @@ namespace KGySoft.Serialization.Binary
         /// <para>Default state at serialization methods in <see cref="BinarySerializer"/>: <strong>Disabled</strong></para>
         /// </summary>
         AllowNonSerializableExpectedCustomTypes = 1 << 13,
+
+        /// <summary>
+        /// Enable ctor invocation during deserialization.
+        /// By default objects are created without ctor invocation, unless they are IBinarySerializable.
+        /// This flag will ensure that parameterless ctor, or one accepting IBinarySerializable inputs, will be invoked if found.
+        /// </summary>
+        AlwaysTryInvokeCtorWhenDeserializing = 1 << 14,
     }
 }


### PR DESCRIPTION
Small patch to expose existing logic to attempt ctor call when object is being created.
No core logic has been modified, just existing functionality exposed via options enum. Unit test covering new usecase were added, existing unit test pass as expected.

Useful when dealing with legacy codebase suffering from decades of technological debt, where programmers of past made peculiar assumptions on how quality code looks like. Which sounds like a typical project where binary serialization is being used.

Option to enable such behavior would also be useful when slowly mowing away from binary serialization and toward json/xml, where default ctors are being called. (leaving aside questionable wisdom of parameterless ctors holding business logic in DTO's)